### PR TITLE
removed MaxPermSize parameter in gradle.properties as permanent gener…

### DIFF
--- a/ready-to-use-ui-demo/gradle.properties
+++ b/ready-to-use-ui-demo/gradle.properties
@@ -18,4 +18,4 @@
 # org.gradle.parallel=true
 android.enableJetifier=true
 android.useAndroidX=true
-org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options\="-Xmx3072M" -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx3072M -Dkotlin.daemon.jvm.options="-Xmx3072M"


### PR DESCRIPTION
…ation has been replaced by Metaspace and setting MaxPermSize  wont have any affect.  Works fine fine Java8 and late versions