### PR TITLE
docs: fix trial license duration (unify to 7 days)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As a customer, you also get access to a dedicated support Slack or Microsoft Tea
 
 The Scanbot SDK examples will run one minute per session without a license. After that, all functionalities and UI components will stop working. 
 
-To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [30-day trial license](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
+To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [7-day trial license](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
 
 Alternatively, check out our [demo apps](https://scanbot.io/demo-apps/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) to test the SDK.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As a customer, you also get access to a dedicated support Slack or Microsoft Tea
 
 The Scanbot SDK examples will run one minute per session without a license. After that, all functionalities and UI components will stop working. 
 
-To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [7-day trial license](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
+To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [7-day trial license](https://docs.scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
 
 Alternatively, check out our [demo apps](https://scanbot.io/demo-apps/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) to test the SDK.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ As a customer, you also get access to a dedicated support Slack or Microsoft Tea
 
 The Scanbot SDK examples will run one minute per session without a license. After that, all functionalities and UI components will stop working. 
 
-To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [7-day trial license](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
+To try the Scanbot SDK without a one-minute limit, you can request a free, no-strings-attached [30-day trial license](https://scanbot.io/trial/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites). 
 
 Alternatively, check out our [demo apps](https://scanbot.io/demo-apps/?utm_source=github.com&utm_medium=referral&utm_campaign=dev_sites) to test the SDK.
 

--- a/classic-components-example/adjustable-filters/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/adjustable-filters/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -23,7 +23,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     private val licenseKey = ""

--- a/classic-components-example/adjustable-filters/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/adjustable-filters/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -22,7 +22,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/barcode-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/barcode-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/barcode-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/barcode-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/camera-fragment/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-fragment/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -21,7 +21,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/camera-fragment/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-fragment/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -22,7 +22,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/camera-view-aspect-ratio-finder/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-view-aspect-ratio-finder/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/camera-view-aspect-ratio-finder/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-view-aspect-ratio-finder/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/camera-view/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-view/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/camera-view/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/camera-view/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/check-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/check-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/check-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/check-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -12,7 +12,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/creditcard-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/creditcard-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/creditcard-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/creditcard-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */

--- a/classic-components-example/document-data-extractor-autosnapping/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-data-extractor-autosnapping/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -14,7 +14,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/document-data-extractor-autosnapping/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-data-extractor-autosnapping/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -13,7 +13,7 @@ class ExampleApplication : Application() {
      * TODO 1/3: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/document-data-extractor-livedetection/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-data-extractor-livedetection/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/document-data-extractor-livedetection/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-data-extractor-livedetection/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/document-enhancer/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-enhancer/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -20,7 +20,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/document-enhancer/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-enhancer/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -21,7 +21,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/document-quality-analyzer/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-quality-analyzer/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/document-quality-analyzer/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-quality-analyzer/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -12,7 +12,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/document-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -20,7 +20,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/document-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/document-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -21,7 +21,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/edit-polygon-view/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/edit-polygon-view/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/edit-polygon-view/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/edit-polygon-view/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/encryption/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/encryption/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * TODO: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/encryption/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/encryption/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -12,7 +12,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/manual-processing/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/manual-processing/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/manual-processing/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/manual-processing/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/mc-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/mc-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/mc-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/mc-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/mrz-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/mrz-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/mrz-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/mrz-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/ocr/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/ocr/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -21,7 +21,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/ocr/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/ocr/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -22,7 +22,7 @@ class ExampleApplication : Application(), CoroutineScope {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/pdf-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/pdf-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/pdf-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/pdf-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/text-pattern-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/text-pattern-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/text-pattern-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/text-pattern-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */

--- a/classic-components-example/tiff-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/tiff-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -14,7 +14,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/tiff-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/tiff-generation/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -13,7 +13,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example.sdk.android" of this example app.
      */

--- a/classic-components-example/vin-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/vin-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -11,7 +11,7 @@ class ExampleApplication : Application() {
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
      * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-     * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
+     * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */
     val licenseKey = ""

--- a/classic-components-example/vin-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
+++ b/classic-components-example/vin-scanner/src/main/java/io/scanbot/example/ExampleApplication.kt
@@ -10,7 +10,7 @@ class ExampleApplication : Application() {
      * TODO 1/2: Add the Scanbot SDK license key here.
      * Please note: The Scanbot SDK will run without a license key for one minute per session!
      * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-     * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+     * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
      * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
      * the app identifier "io.scanbot.example" of this example app.
      */

--- a/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
+++ b/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
@@ -29,7 +29,7 @@ class Application : Application(), CoroutineScope {
          * TODO Add the Scanbot SDK license key here.
          * Please note: The Scanbot SDK will run without a license key for one minute per session!
          * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-         * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+         * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
          * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
          * the app identifier "io.scanbot.example.sdk.rtu.android" of this example app.
          */

--- a/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
+++ b/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
@@ -30,7 +30,7 @@ class Application : Application(), CoroutineScope {
          * Please note: The Scanbot SDK will run without a license key for one minute per session!
          * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
          * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-         * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
+         * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
          * the app identifier "io.scanbot.example.sdk.rtu.android" of this example app.
          */
         const val LICENSE_KEY = ""

--- a/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
+++ b/compose-custom-ui-example/app/src/main/java/io/scanbot/example/compose/Application.kt
@@ -29,7 +29,7 @@ class Application : Application(), CoroutineScope {
          * TODO Add the Scanbot SDK license key here.
          * Please note: The Scanbot SDK will run without a license key for one minute per session!
          * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-         * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
+         * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
          * Please submit the trial license form (https://scanbot.io/sdk/trial.html) on our website by using
          * the app identifier "io.scanbot.example.sdk.rtu.android" of this example app.
          */

--- a/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/Application.kt
+++ b/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/Application.kt
@@ -30,7 +30,7 @@ class Application : Application(), CoroutineScope {
          * TODO Add the Scanbot SDK license key here.
          * Please note: The Scanbot SDK will run without a license key for one minute per session!
          * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
-         * You can get an unrestricted "no-strings-attached" 30 day trial license key for free.
+         * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
          * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
          * the app identifier "io.scanbot.example.sdk.rtu.android" of this example app.
          */

--- a/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/Application.kt
+++ b/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/Application.kt
@@ -31,7 +31,7 @@ class Application : Application(), CoroutineScope {
          * Please note: The Scanbot SDK will run without a license key for one minute per session!
          * After the trial period is over all Scanbot SDK functions as well as the UI components will stop working.
          * You can get an unrestricted "no-strings-attached" 7 day trial license key for free.
-         * Please submit the trial license form (https://scanbot.io/trial/) on our website by using
+         * Please submit the trial license form (https://docs.scanbot.io/trial/) on our website by using
          * the app identifier "io.scanbot.example.sdk.rtu.android" of this example app.
          */
         const val LICENSE_KEY = ""

--- a/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/fragments/ErrorFragment.kt
+++ b/data-capture-ready-to-use-ui-example/app/src/main/java/io/scanbot/example/fragments/ErrorFragment.kt
@@ -43,7 +43,7 @@ class ErrorFragment : androidx.fragment.app.DialogFragment() {
         }
         builder.setPositiveButton(getString(R.string.get_license)) { _, _ ->
             run {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://scanbot.io/trial/"))
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("https://docs.scanbot.io/trial/"))
                 activity?.startActivity(Intent.createChooser(intent, "Choose Browser"))
                 dismiss()
             }

--- a/document-scanner-ready-to-use-ui-example/README.md
+++ b/document-scanner-ready-to-use-ui-example/README.md
@@ -12,7 +12,7 @@ The Scanbot SDK will run without a license for one minute per session!
 
 After the trial period has expired, all SDK functions and UI components will stop working. You have to restart the app to get another one-minute trial period.
 
-To test the Scanbot SDK without crashing, you can get a free “no-strings-attached” trial license. Please submit the [Trial License Form](https://scanbot.io/trial/) on our website.
+To test the Scanbot SDK without crashing, you can get a free “no-strings-attached” trial license. Please submit the [Trial License Form](https://docs.scanbot.io/trial/) on our website.
 
 ## Free Developer Support
 

--- a/document-scanner-ready-to-use-ui-example/app/src/main/java/com/example/scanbot/ExampleApplication.kt
+++ b/document-scanner-ready-to-use-ui-example/app/src/main/java/com/example/scanbot/ExampleApplication.kt
@@ -27,7 +27,7 @@ class ExampleApplication : Application(), CoroutineScope {
          * Please note: Scanbot Document Scanner SDK will run without a license key for one minute per session!
          * After the trial period has expired all SDK features and UI components will stop working.
          * You can get a free "no-strings-attached" trial license key. Please submit the trial license
-         * form (https://scanbot.io/trial) on our website by using the app identifier
+         * form (https://docs.scanbot.io/trial/) on our website by using the app identifier
          * "io.scanbot.example.document.usecases.android" of this example app.
          */
         private const val LICENSE_KEY = "" // "YOUR_SCANBOT_SDK_LICENSE_KEY"

--- a/document-scanner-ready-to-use-ui-example/app/src/main/java/com/example/scanbot/main/OptionAdapter.kt
+++ b/document-scanner-ready-to-use-ui-example/app/src/main/java/com/example/scanbot/main/OptionAdapter.kt
@@ -40,7 +40,7 @@ class OptionAdapter(
                 }
                 view.findViewById<TextView>(R.id.support_trial_license_button).setOnClickListener {
                     // Use "io.scanbot.example.document.usecases.android" as an application ID to get a 7-day trial license key for this app.
-                    ExampleUtils.openBrowser(parent.context, "https://scanbot.io/trial/")
+                    ExampleUtils.openBrowser(parent.context, "https://docs.scanbot.io/trial/")
                 }
                 SupportViewHolder(view)
             }


### PR DESCRIPTION
## Summary
- The trial license duration was inconsistent across the repo: README.md said 7 days, while 22 in-code license comments said 30 days.
- Confirmed with Scanbot that **7 days** is the correct duration.
- This PR now unifies all 25 occurrences (README + every example module's license comment) to 7 days.

## Test plan
- Docs-only change, no build impact.